### PR TITLE
Keep the secret at even length

### DIFF
--- a/app/totp.js
+++ b/app/totp.js
@@ -19,9 +19,10 @@ function TOTP(secretZBase32) {
 
     var secretHex = zbase32ToHex(this.secretZBase32);
     if (secretHex.length % 2 !== 0) {
-      secretHex = '0' + secretHex;
       if(secretHex.endsWith('0')) {
         secretHex = secretHex.slice(0, -1);
+      }else{
+        secretHex = '0' + secretHex;
       }
     }
     shaObj.setHMACKey(secretHex, "HEX");


### PR DESCRIPTION
If the secret is 65 char long, and ends with a 0, the previous code would add a 0 at the beginning, *and* remove the last 0, keeping a (bad) length of 65.
It should be one or the other, remove a 0, or add one. Not both.

(it fixes issues with secrets like 'L27ZZSYAEF4Y6QQMZOEFBDWKNN7FOID3ZH63NBEQQUHFLH22UE2Q')